### PR TITLE
perf: optimize walkTree adjustPath with O(1) WeakMap lookups

### DIFF
--- a/packages/cspell-eslint-plugin/src/spellCheckAST/walkTree.cts
+++ b/packages/cspell-eslint-plugin/src/spellCheckAST/walkTree.cts
@@ -7,26 +7,16 @@ import type { ASTPath, ASTPathElement, Key } from './ASTPath.js' with { 'resolut
 const debugMode = false;
 
 export function walkTree(node: ASTNode, enter: (path: ASTPath) => void): void {
-    const visited = new Set<object>();
-
-    let pathNode: ASTPath | undefined = undefined;
+    const visited = new WeakSet<object>();
+    const pathByNode = new WeakMap<ASTNode, ASTPath>();
 
     function adjustPath(n: ASTPath): ASTPath {
-        if (!n.parent || !pathNode) {
-            pathNode = n;
+        if (!n.parent) {
             n.prev = undefined;
-            return n;
+        } else {
+            n.prev = pathByNode.get(n.parent) || undefined;
         }
-        if (pathNode.node === n.parent) {
-            n.prev = pathNode;
-            pathNode = n;
-            return n;
-        }
-        while (pathNode && pathNode.node !== n.parent) {
-            pathNode = pathNode.prev;
-        }
-        n.prev = pathNode;
-        pathNode = n;
+        pathByNode.set(n.node, n);
         return n;
     }
 


### PR DESCRIPTION
Replace O(n) linear search through prev chain with WeakMap-based O(1) parent lookups. Also replace Set with WeakSet for better memory management of visited nodes.